### PR TITLE
Jenkins 33567

### DIFF
--- a/war/src/main/js/config-scrollspy.js
+++ b/war/src/main/js/config-scrollspy.js
@@ -20,6 +20,8 @@ function notify(event) {
 }
 
 $(function() {
+    //make sure the window starts at the top to activate the tab pegging
+    $(window).scrollTop(0);
     var tabBarWidget = require('./widgets/config/tabbar.js');
 
     tabBarWidget.addPageTabs('.config-table.scrollspy', function(tabBar) {

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -92,7 +92,7 @@ body {
   margin-left: 320px;
 }
 
-body#jenkins.j-hide-left #main-panel {
+body#jenkins.main-panel-only #main-panel {
   max-width:70em;
   margin:0 auto;
 }
@@ -172,12 +172,12 @@ body, table, form, input, td, th, p, textarea, select
 }
 
 @media (min-width:1600px){
-  body#jenkins.j-hide-left #main-panel{max-width:75%}
+  body#jenkins.main-panel-only #main-panel{max-width:75%}
   body, table, form, input, td, th, p, textarea, select, #tasks .task
     {font-size:14px;}  
 }
 @media (min-width:2000px){
-  body#jenkins.j-hide-left #main-panel{max-width:85%}
+  body#jenkins.main-panel-only #main-panel{max-width:85%}
   body, table, form, input, td, th, p, textarea, select, #tasks .task
     {font-size:15px;}  
 }


### PR DESCRIPTION
[FIX JENKINS-33567] Forcing the window to start at the top assures that the tabs will pin correctly to the top of the page and the tabs will be synched.
