### PR TITLE
Fix new item page loading weirdness

### DIFF
--- a/core/src/main/resources/hudson/model/View/newJob.jelly
+++ b/core/src/main/resources/hudson/model/View/newJob.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
     <l:css src="jsbundles/add-item.css" />
 
     <l:main-panel>
-
+      <div id="create-item-panel" style="display: none;">
       <s:form method="post" action="createItem" name="createItem">
 
         <j:if test="${!empty(app.itemMap)}">
@@ -61,6 +61,7 @@ THE SOFTWARE.
         </s:bottomButtonBar>  
         
       </s:form>
+      </div>
 
     </l:main-panel>
   </l:layout>

--- a/core/src/main/resources/hudson/model/View/newJob.jelly
+++ b/core/src/main/resources/hudson/model/View/newJob.jelly
@@ -29,12 +29,11 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:getStatic var="permission" className="hudson.model.Item" field="CREATE"/>
 
-  <l:layout norefresh="true" cssclass="add-item" permission="${permission}" title="${%NewJob(it.newPronoun)}">
+  <l:layout norefresh="true" cssclass="add-item main-panel-only" permission="${permission}" title="${%NewJob(it.newPronoun)}">
 
     <l:js src="jsbundles/add-item.js" />
     <l:css src="jsbundles/add-item.css" />
 
-    <st:include page="sidepanel.jelly" />
     <l:main-panel>
 
       <s:form method="post" action="createItem" name="createItem">

--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -29,12 +29,7 @@ $.when(getItems()).done(function(data){
     var $tabs = $('<div class="jenkins-config-widgets" />').appendTo($newView);
     var $categories = $('<div class="categories" />').appendTo($newView);
     var $subBtn = $('#bottom-sticker .yui-submit-button');
-    var sectionsToShow = [];    
-
-    ////////////////////////////////
-    // mark page for layout
-    $('body').addClass('add-item main-panel-only');
-
+    var sectionsToShow = [];
 
     ////////////////////////////////
     // submit button click

--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -15,6 +15,11 @@ var jRoot = $('head').attr('data-rooturl');
 
 $.when(getItems()).done(function(data){
   $(function() {
+
+    // The main panel content is hidden by default via an
+    // inline style. We're ready to remove that now.
+    $('#create-item-panel').removeAttr('style');
+
     //////////////////////////////
     // helpful reference DOM
 


### PR DESCRIPTION
- [x] Remove the sidepanel completely so we don't have to then remove it via JavaScript
- [x] Hide the new item main panel content until we're ready to display it. This gets rid of some weird style application timing issues.
