### PR TITLE
Fix "weight" based sorting algo

### DIFF
--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -155,9 +155,10 @@ $.when(getItems()).done(function(data){
     }
     function sortItemsByOrder(itemTypes) {
       function sortByOrder(a, b) {
-        var aOrder = a.weight;
-        var bOrder = b.weight;
-        return ( (aOrder < bOrder) ? -1 : ( (aOrder === bOrder) ? 1 : 0));
+        var result = (a.weight - b.weight);
+        result = Math.max(result, -1); // If lt than -1, make it -1
+        result = Math.min(result, +1); // If gt than +1, make it +1
+        return result;
       }
       return itemTypes.sort(sortByOrder);
     }


### PR DESCRIPTION
This fixes the different sorting as seen between Chrome, FF and Safari.

`(aOrder === bOrder) ? 1 : 0` should have been `(aOrder > bOrder) ? 1 : 0`. In any case, I think it's more readable to just use `Math.min` and `Math.max`.
