### PR TITLE
Ignore the window scroll event that's generated from the repositioning of the new item page tabbar

### DIFF
--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -63,7 +63,14 @@ $.when(getItems()).done(function(data){
     ////////////////////////////////
     // scroll action......
 
+    var isManualScrolling = false;
     function watchScroll(){
+      if (isManualScrolling) {
+        // We ignore scroll events when a manual scroll is in
+        // operation e.g. when the user clicks on a category tab.
+        return;
+      }      
+      
       var $window = $(window);
       var $jenkTools = $('#breadcrumbBar');
       var winScoll = $window.scrollTop();
@@ -253,7 +260,6 @@ $.when(getItems()).done(function(data){
       if(!elem) {elem = i;}
       var $tab = $(['<li><a class="tab ',((i===0)?'active':''),'" href="#',cleanHref(elem.id),'">',elem.name,'</a></li>'].join(''))
         .click(function(){
-          //e.preventDefault(e);
           var $this = $(this).children('a');
 
           var tab = $this.attr('href');
@@ -261,9 +267,12 @@ $.when(getItems()).done(function(data){
 
           setTimeout(function(){resetActiveTab($this);},510);
 
+          isManualScrolling = true;
           $('html,body').animate({
             scrollTop: scrollTop
-          }, 500);
+          }, 500, function() {
+            isManualScrolling = false;
+          });
         });
       return $tab;
     }

--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -64,12 +64,19 @@ $.when(getItems()).done(function(data){
     // scroll action......
 
     var isManualScrolling = false;
+    var ignoreNextScrollEvent = false;
     function watchScroll(){
-      if (isManualScrolling) {
+      if (isManualScrolling === true) {
         // We ignore scroll events when a manual scroll is in
         // operation e.g. when the user clicks on a category tab.
         return;
       }      
+      if (ignoreNextScrollEvent === true) {
+        // Things like repositioning of the tabbar (see stickTabbar)
+        // can trigger scroll events that we want to ignore.
+        ignoreNextScrollEvent = false;
+        return;
+      }
       
       var $window = $(window);
       var $jenkTools = $('#breadcrumbBar');
@@ -96,6 +103,7 @@ $.when(getItems()).done(function(data){
           'position':'fixed',
           'top':($jenkTools.height() - 5 )+'px'});
         $categories.css({'margin-top':$tabs.outerHeight()+'px'});
+        ignoreNextScrollEvent = true;
       }
       else{
         $tabs.add($categories).removeAttr('style');

--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -72,8 +72,8 @@ $.when(getItems()).done(function(data){
         return;
       }      
       if (ignoreNextScrollEvent === true) {
-        // Things like repositioning of the tabbar (see stickTabbar)
-        // can trigger scroll events that we want to ignore.
+        // Things like repositioning of the tabbar can trigger scroll
+        // events that we want to ignore.
         ignoreNextScrollEvent = false;
         return;
       }


### PR DESCRIPTION
Repositioning of the tabbar causes a scroll event to happen, which causes tab activation/reactivation, which in turn causes a further autoscroll etc etc. Is the cause of the weird scrolling behavior as seen by @daniel-beck.
